### PR TITLE
Inventory search

### DIFF
--- a/apps/backend/src/main/java/ch/heig/pdg/backend/presentation/InventoryController.java
+++ b/apps/backend/src/main/java/ch/heig/pdg/backend/presentation/InventoryController.java
@@ -1,6 +1,7 @@
 package ch.heig.pdg.backend.presentation;
 
 import ch.heig.pdg.backend.dto.InventoryDTO;
+import ch.heig.pdg.backend.dto.SearchResultDTO;
 import ch.heig.pdg.backend.entities.Inventory;
 import ch.heig.pdg.backend.security.annotations.AuthenticationRequired;
 import ch.heig.pdg.backend.services.InventoryService;
@@ -68,6 +69,15 @@ public class InventoryController implements ch.heig.pdg.backend.api.InventoryApi
     public ResponseEntity<InventoryDTO> updateInventory(Integer id, InventoryDTO inventoryDTO) {
         return new ResponseEntity<>(
                 this.inventoryService.updateInventory(id, inventoryDTO),
+                HttpStatus.OK
+        );
+    }
+
+    @AuthenticationRequired
+    @Override
+    public ResponseEntity<List<SearchResultDTO>> searchInventory(String searchTerm, Integer id) {
+        return new ResponseEntity<>(
+                this.inventoryService.searchInventory(searchTerm, id),
                 HttpStatus.OK
         );
     }

--- a/apps/backend/src/main/java/ch/heig/pdg/backend/repositories/ItemModelRepository.java
+++ b/apps/backend/src/main/java/ch/heig/pdg/backend/repositories/ItemModelRepository.java
@@ -2,10 +2,15 @@ package ch.heig.pdg.backend.repositories;
 
 import ch.heig.pdg.backend.entities.ItemModel;
 import ch.heig.pdg.backend.repositories.criteria.CriteriaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ItemModelRepository extends CrudRepository<ItemModel, Integer>, PagingAndSortingRepository<ItemModel, Integer>, CriteriaRepository<ItemModel, Integer> {
+    @Query("SELECT im FROM ItemModel im WHERE im.inventory.id = :inventoryId AND (im.name LIKE %:searchTerm% OR im.description LIKE %:searchTerm%)")
+    List<ItemModel> search(Integer inventoryId, String searchTerm);
 }

--- a/apps/backend/src/main/java/ch/heig/pdg/backend/repositories/LocationRepository.java
+++ b/apps/backend/src/main/java/ch/heig/pdg/backend/repositories/LocationRepository.java
@@ -2,10 +2,15 @@ package ch.heig.pdg.backend.repositories;
 
 import ch.heig.pdg.backend.entities.Location;
 import ch.heig.pdg.backend.repositories.criteria.CriteriaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface LocationRepository extends CrudRepository<Location, Integer>, PagingAndSortingRepository<Location, Integer>, CriteriaRepository<Location, Integer> {
+    @Query("SELECT l FROM Location l WHERE l.inventory.id = :inventoryId AND (l.name LIKE %:searchTerm% OR l.description LIKE %:searchTerm%)")
+    List<Location> search(Integer inventoryId, String searchTerm);
 }

--- a/apps/backend/src/main/java/ch/heig/pdg/backend/repositories/UserRepository.java
+++ b/apps/backend/src/main/java/ch/heig/pdg/backend/repositories/UserRepository.java
@@ -2,10 +2,12 @@ package ch.heig.pdg.backend.repositories;
 
 import ch.heig.pdg.backend.entities.User;
 import ch.heig.pdg.backend.repositories.criteria.CriteriaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,4 +15,7 @@ public interface UserRepository extends CrudRepository<User, Integer>, PagingAnd
     Optional<User> findByUsername(String username);
 
     void deleteByUsername(String username);
+
+    @Query("SELECT u FROM User u WHERE :inventoryId IN (SELECT i1.id FROM Inventory i1 WHERE i1.owner = u OR u MEMBER OF i1.users) AND (u.firstName LIKE %:searchTerm% OR u.lastName LIKE %:searchTerm%)")
+    List<User> search(Integer inventoryId, String searchTerm);
 }

--- a/apps/backend/src/main/java/ch/heig/pdg/backend/services/InventoryService.java
+++ b/apps/backend/src/main/java/ch/heig/pdg/backend/services/InventoryService.java
@@ -1,6 +1,7 @@
 package ch.heig.pdg.backend.services;
 
 import ch.heig.pdg.backend.dto.InventoryDTO;
+import ch.heig.pdg.backend.dto.SearchResultDTO;
 import ch.heig.pdg.backend.dto.mapping.InventoryMapper;
 import ch.heig.pdg.backend.entities.Inventory;
 import ch.heig.pdg.backend.repositories.InventoryRepository;
@@ -9,14 +10,21 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 public class InventoryService extends AbstractService {
     private final InventoryMapper inventoryMapper;
+    private final LocationService locationService;
+    private final UserService userService;
+    private final ItemModelService itemModelService;
 
-    protected InventoryService(InventoryRepository inventoryRepository, InventoryMapper inventoryMapper) {
+    protected InventoryService(InventoryRepository inventoryRepository, InventoryMapper inventoryMapper, LocationService locationService, UserService userService, ItemModelService itemModelService) {
         super(inventoryRepository);
         this.inventoryMapper = inventoryMapper;
+        this.locationService = locationService;
+        this.userService = userService;
+        this.itemModelService = itemModelService;
     }
 
     public List<InventoryDTO> getInventories(HugoSearchFilter<Inventory> filter) {
@@ -25,6 +33,41 @@ public class InventoryService extends AbstractService {
                 .stream()
                 .map(inventory -> (InventoryDTO) this.inventoryMapper.getDTO(inventory))
                 .collect(Collectors.toList());
+    }
+
+    public List<SearchResultDTO> searchInventory(String searchTerm, Integer inventoryId) {
+        Stream<SearchResultDTO> users = this.userService.search(inventoryId, searchTerm).stream().map(
+                u -> {
+                    SearchResultDTO dto = new SearchResultDTO();
+                    dto.id(u.getId());
+                    dto.entityType("user");
+                    dto.description("");
+                    dto.name(u.getFirstName() + " " + u.getLastName());
+                    return dto;
+                }
+        );
+        Stream<SearchResultDTO> locations = this.locationService.search(inventoryId, searchTerm).stream().map(
+                l -> {
+                    SearchResultDTO dto = new SearchResultDTO();
+                    dto.id(l.getId());
+                    dto.entityType("location");
+                    dto.description(l.getDescription());
+                    dto.name(l.getName());
+                    return dto;
+                }
+        );
+        Stream<SearchResultDTO> itemModels = this.itemModelService.search(inventoryId, searchTerm).stream().map(
+                i -> {
+                    SearchResultDTO dto = new SearchResultDTO();
+                    dto.id(i.getId());
+                    dto.entityType("itemModel");
+                    dto.description(i.getDescription());
+                    dto.name(i.getName());
+                    return dto;
+                }
+        );
+
+        return Stream.of(locations, users, itemModels).flatMap(o -> o).collect(Collectors.toList());
     }
 
     public InventoryDTO getInventory(Integer id) {

--- a/apps/backend/src/main/java/ch/heig/pdg/backend/services/ItemModelService.java
+++ b/apps/backend/src/main/java/ch/heig/pdg/backend/services/ItemModelService.java
@@ -23,6 +23,14 @@ public class ItemModelService extends AbstractService {
         this.itemModelMapper = itemModelMapper;
     }
 
+    public List<ItemModelDTO> search(Integer inventoryId, String searchTerm) {
+        return this.itemModelRepository
+                .search(inventoryId, searchTerm)
+                .stream()
+                .map(i -> (ItemModelDTO) this.itemModelMapper.getDTO(i))
+                .collect(Collectors.toList());
+    }
+
     public ItemModelDTO addItemModel(Integer inventoryId, ItemModelDTO itemModelDTO) {
         Inventory inventory = this.checkInventory(inventoryId);
 

--- a/apps/backend/src/main/java/ch/heig/pdg/backend/services/LocationService.java
+++ b/apps/backend/src/main/java/ch/heig/pdg/backend/services/LocationService.java
@@ -34,6 +34,14 @@ public class LocationService extends AbstractService {
         );
     }
 
+    public List<LocationDTO> search(Integer inventoryId, String searchTerm) {
+        return this.locationRepository
+                .search(inventoryId, searchTerm)
+                .stream()
+                .map(l -> (LocationDTO) this.locationMapper.getDTO(l))
+                .collect(Collectors.toList());
+    }
+
     public LocationDTO removeLocation(Integer id) {
         LocationDTO locationDTO = (LocationDTO) this.locationMapper.getDTO(this.getEntityIfExists(id, this.locationRepository));
         this.locationRepository.deleteById(id);

--- a/apps/backend/src/main/java/ch/heig/pdg/backend/services/UserService.java
+++ b/apps/backend/src/main/java/ch/heig/pdg/backend/services/UserService.java
@@ -35,6 +35,14 @@ public class UserService extends AbstractService {
         );
     }
 
+    public List<UserDTO> search(Integer inventoryId, String searchTerm) {
+        return this.userRepository
+                .search(inventoryId, searchTerm)
+                .stream()
+                .map(u -> (UserDTO) this.userMapper.getDTO(u))
+                .collect(Collectors.toList());
+    }
+
     public UserDTO removeUser(Integer id) {
         if (!Objects.equals(this.currentUser.getCurrentUserData().userId, id)) {
             throw new ForbiddenOperationException("Can not remove other user");

--- a/apps/backend/src/main/resources/api.yaml
+++ b/apps/backend/src/main/resources/api.yaml
@@ -1155,6 +1155,48 @@ paths:
           $ref: "#/components/responses/500"
       security:
         - JWTAuth: []
+  "/inventory/{id}/search":
+    parameters:
+      - in: query
+        name: searchTerm
+        schema:
+          type: string
+        required: true
+        description: Numeric of the current inventory
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+        description: Numeric ID of the inventory to search in
+    get:
+      tags:
+        - Inventory
+      description: Search locations, item models and users
+      operationId: searchInventory
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SearchResultDTO"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
+          $ref: "#/components/responses/409"
+        "500":
+          $ref: "#/components/responses/500"
+      security:
+        - JWTAuth: [ ]
 components:
   schemas:
     JSONErrorMessage:
@@ -1310,6 +1352,17 @@ components:
           type: array
           items:
             type: integer
+    SearchResultDTO:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+        entityType:
+          type: string
     JWTDTO:
       type: object
       properties:

--- a/apps/backend/src/test/java/ch/heig/pdg/backend/integration/InventoryControllerIntegrationTest.java
+++ b/apps/backend/src/test/java/ch/heig/pdg/backend/integration/InventoryControllerIntegrationTest.java
@@ -26,6 +26,45 @@ public class InventoryControllerIntegrationTest extends AbstractAuthenticatedInt
     }
 
     @Test
+    public void givenInventoryValid_whenSearchInventoryForTermThatMatchesAUser_thenResultsPresent() throws Exception {
+        this.mvc.perform(get("/inventory/1/search?searchTerm=aul")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + this.token)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].entityType").value("user"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].name").value("Paul Test"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].description").value(""));
+    }
+
+    @Test
+    public void givenInventoryValid_whenSearchInventoryForTermThatMatchesALocation_thenResultsPresent() throws Exception {
+        this.mvc.perform(get("/inventory/1/search?searchTerm=other description")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + this.token)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].entityType").value("location"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].name").value("another name"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].description").value("an other description"));
+    }
+
+    @Test
+    public void givenInventoryValid_whenSearchInventoryForTermThatMatchesAnItemModel_thenResultsPresent() throws Exception {
+        this.mvc.perform(get("/inventory/1/search?searchTerm=notCommonDes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + this.token)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].entityType").value("itemModel"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].name").value("name"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].description").value("notCommonDesc"));
+    }
+
+    @Test
     public void givenInventory_whenGetInventory_thenStatus200() throws Exception {
         this.mvc.perform(get("/inventories/1")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/apps/backend/src/test/java/ch/heig/pdg/backend/integration/ItemModelControllerIntegrationTest.java
+++ b/apps/backend/src/test/java/ch/heig/pdg/backend/integration/ItemModelControllerIntegrationTest.java
@@ -64,7 +64,7 @@ public class ItemModelControllerIntegrationTest extends AbstractAuthenticatedInt
                 )
                 .andExpect(status().isCreated())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(3))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.name").value(itemModelName))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.description").value(description));
     }

--- a/apps/backend/src/test/resources/integration-data.sql
+++ b/apps/backend/src/test/resources/integration-data.sql
@@ -36,7 +36,8 @@ VALUES (1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'location description', 'locati
 
 -- ItemModel
 INSERT INTO item_model(id, created_at, updated_at, description, name, inventory_id)
-VALUES (1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'description', 'name', 1);
+VALUES (1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'description', 'name', 1),
+       (2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'notCommonDesc', 'name', 1);
 
 INSERT INTO item(id, created_at, updated_at, model_id)
 VALUES (1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1);


### PR DESCRIPTION
Implements
- https://github.com/PDG-2023/Project/issues/56

Search endpoint is `/inventory/{id}/search&searchTerm=STRING`

Results are returned as in an array of the DTO below
```yaml
SearchResultDTO:
  type: object
  properties:
    id:
      type: integer
    name:
      type: string
    description:
      type: string
    entityType:
      type: string
```

Where `entityType` can be any of `location`, `user`, `itemModel`

Fields searched are description and name for locations and item models, firstName and lastName for users.

Added tests to back the implementation.


> __Warning__
> This branch is based on `dev/total` and not master, because reasons. Be cautious when merging.
