### PR TITLE
Add the `distinct` keyword for entity filter

### DIFF
--- a/apps/backend/src/main/java/ch/heig/pdg/backend/repositories/criteria/CriteriaRepositoryImpl.java
+++ b/apps/backend/src/main/java/ch/heig/pdg/backend/repositories/criteria/CriteriaRepositoryImpl.java
@@ -142,7 +142,7 @@ public class CriteriaRepositoryImpl<T, ID> implements CriteriaRepository<T, ID> 
         }
 
         criteriaQuery.orderBy(ordering);
-        TypedQuery<T> query = entityManager.createQuery(criteriaQuery);
+        TypedQuery<T> query = entityManager.createQuery(criteriaQuery.distinct(true));
 
         if (addLimitOffset) {
             if (maxResults != null) {


### PR DESCRIPTION
I think that the `distinct` should be there by default (as the data is not nested).

@noahboegli Do you think it should be a parameter or could it break something elsewhere?